### PR TITLE
Fix useMediaQuery to support Safari

### DIFF
--- a/packages/core/useMediaQuery/index.ts
+++ b/packages/core/useMediaQuery/index.ts
@@ -11,13 +11,15 @@ function matchMediaListener(mediaQuery: any, handler: (event: MediaQueryListEven
 
   try {
     // Chrome & Firefox
-    mediaQuery.addEventListener('change', handler);
-  } catch (e1) {
+    mediaQuery.addEventListener('change', handler)
+  }
+  catch (e1) {
     try {
       // Safari
-      mediaQuery.addListener(handler);
-    } catch (e2) {
-      console.error(e1, e2);
+      mediaQuery.addListener(handler)
+    }
+    catch (e2) {
+      console.error(e1, e2)
     }
   }
 }


### PR DESCRIPTION
I had problems using useMediaQuery on an iPhone 7. With the changes I could get it working.