### PR TITLE
fix: support changes of element width for useTextareaAutosize

### DIFF
--- a/packages/core/useTextareaAutosize/index.ts
+++ b/packages/core/useTextareaAutosize/index.ts
@@ -1,6 +1,7 @@
 import type { MaybeRef } from '@vueuse/shared'
 import type { WatchSource } from 'vue-demi'
 import { ref, watch } from 'vue-demi'
+import useResizeObserver from '../useResizeObserver'
 
 export interface UseTextareaAutosizeOptions {
   /** Textarea element to autosize. */
@@ -28,6 +29,8 @@ export function useTextareaAutosize(options?: UseTextareaAutosizeOptions) {
   }
 
   watch([input, textarea], triggerResize, { immediate: true })
+  
+  useResizeObserver(() => triggerResize())
 
   if (options?.watch)
     watch(options.watch, triggerResize, { immediate: true, deep: true })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`useTextareaAutosize` currently doesn't update if the element size is changed.
This can e.g. happen of change of the window size if the textarea is styled with a width of 100%.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
